### PR TITLE
Update parser.js

### DIFF
--- a/src/engines/parser.js
+++ b/src/engines/parser.js
@@ -58,7 +58,7 @@ function orchestrate(arr) {
             // quoted bracket "{" won't trigger recursion
             if (arr[i].endsWith('{') && arr.length !== 1) {
                 let c = 0;
-                while (arr[i + c] !== '    }') {
+                while (arr[i + c] !== '    }' && arr[i + c] !== '}') {
                     c += 1;
                     if ((i + c) >= arr.length) {
                         throw new Error(`Missing or mis-indented '}' for line: '${arr[i]}'`);


### PR DESCRIPTION
sometimes nested objects in the config file are not indented and this causes the parser to break because the while loop doesn't exit and we reach the end of the object with no closing bracket detected.

the behavior can be observed in issue 99:
https://github.com/f5devcentral/f5-automation-config-converter/issues/99

I've only tested this with `ucs` argument and my conversion was able to complete successfully afterwards.  I am not too certain if this change would impact anything else.